### PR TITLE
Display sanitized HTML from text columns

### DIFF
--- a/app/views/wallaby/resources/show/_text.html.erb
+++ b/app/views/wallaby/resources/show/_text.html.erb
@@ -2,4 +2,4 @@
 <%# @param field_name [String] name of the field %>
 <%# @param value [Object] value of the field %>
 <%# @param metadata [Hash] metadata of the field %>
-<%= value || null %>
+<%= value ? sanitize(value) : null %>


### PR DESCRIPTION
Text field uses a rich editor by default in forms.
However, it currently displays raw HTML code instead of a pretty version.

This PR solves it and also sanitizes its HTML code.

---

[ActionView::Helpers::SanitizeHelper#sanitize method docs](http://api.rubyonrails.org/classes/ActionView/Helpers/SanitizeHelper.html)