### PR TITLE
Adding link type for links in show and index partials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .bundle/
+.yardoc/
+doc/
 pkg/
 spec/dummy/db/*.sqlite3
 spec/dummy/db/*.sqlite3-journal
@@ -7,6 +9,5 @@ spec/dummy/.sass-cache
 .byebug_history
 *.log
 .DS_Store
-spec/dummy/config/*
 cc-test-reporter
 coverage/

--- a/app/controllers/wallaby/abstract_resources_controller.rb
+++ b/app/controllers/wallaby/abstract_resources_controller.rb
@@ -292,7 +292,7 @@ module Wallaby
     #  (e.g. `wallaby/resources)
     # @return [PrefixesBuilder]
     def _prefixes
-      @_prefixes ||= PrefixesBuilder.new( # rubocop:disable Naming/MemoizedInstanceVariableName
+      @_prefixes ||= PrefixesBuilder.new( # rubocop:disable Naming/MemoizedInstanceVariableName, Metrics/LineLength
         super, controller_path, current_resources_name, params
       ).build
     end

--- a/app/controllers/wallaby/abstract_resources_controller.rb
+++ b/app/controllers/wallaby/abstract_resources_controller.rb
@@ -292,7 +292,7 @@ module Wallaby
     #  (e.g. `wallaby/resources)
     # @return [PrefixesBuilder]
     def _prefixes
-      @_prefixes ||= PrefixesBuilder.new(
+      @_prefixes ||= PrefixesBuilder.new( # rubocop:disable Naming/MemoizedInstanceVariableName
         super, controller_path, current_resources_name, params
       ).build
     end

--- a/app/views/wallaby/resources/index/_link.csv.erb
+++ b/app/views/wallaby/resources/index/_link.csv.erb
@@ -1,0 +1,5 @@
+<%# @param object [model] model instance %>
+<%# @param field_name [String] name of the field %>
+<%# @param value [Object] value of the field %>
+<%# @param metadata [Hash] metadata of the field %>
+<%= raw value %>

--- a/app/views/wallaby/resources/index/_link.html.erb
+++ b/app/views/wallaby/resources/index/_link.html.erb
@@ -2,4 +2,4 @@
 <%# @param field_name [String] name of the field %>
 <%# @param value [Object] value of the field %>
 <%# @param metadata [Hash] metadata of the field %>
-<%= value.nil? ? null : link_to(metadata[:label], value, metadata[:html_options]) %>
+<%= value.nil? ? null : link_to(metadata[:title], value, metadata[:html_options]) %>

--- a/app/views/wallaby/resources/index/_link.html.erb
+++ b/app/views/wallaby/resources/index/_link.html.erb
@@ -1,0 +1,5 @@
+<%# @param object [model] model instance %>
+<%# @param field_name [String] name of the field %>
+<%# @param value [Object] value of the field %>
+<%# @param metadata [Hash] metadata of the field %>
+<%= value.nil? ? null : link_to(metadata[:label], value, metadata[:html_options]) %>

--- a/app/views/wallaby/resources/show/_link.html.erb
+++ b/app/views/wallaby/resources/show/_link.html.erb
@@ -2,4 +2,4 @@
 <%# @param field_name [String] name of the field %>
 <%# @param value [Object] value of the field %>
 <%# @param metadata [Hash] metadata of the field %>
-<%= value.nil? ? null : link_to(metadata[:label], value, metadata[:html_options]) %>
+<%= value.nil? ? null : link_to(metadata[:title], value, metadata[:html_options]) %>

--- a/app/views/wallaby/resources/show/_link.html.erb
+++ b/app/views/wallaby/resources/show/_link.html.erb
@@ -1,0 +1,5 @@
+<%# @param object [model] model instance %>
+<%# @param field_name [String] name of the field %>
+<%# @param value [Object] value of the field %>
+<%# @param metadata [Hash] metadata of the field %>
+<%= value.nil? ? null : link_to(metadata[:label], value, metadata[:html_options]) %>

--- a/docs/view.md
+++ b/docs/view.md
@@ -233,6 +233,11 @@ Apart from the above types, these are also supported:
 - markdown (form)
 - password
 - raw (index/show)
+- link (index/show)
+  - metadata options for `index` partial:
+    - `:html_options`: used by [ActionView::Helpers::UrlHelper#link_to](https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-link_to)
+  - metadata options for `show` partial:
+    - `:html_options`: used by [ActionView::Helpers::UrlHelper#link_to](https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-link_to)
 - sti
   - metadata options for `index` partial:
     - `:max`: Truncates a given text after a given `max` if text is longer than `max`

--- a/docs/view.md
+++ b/docs/view.md
@@ -235,9 +235,11 @@ Apart from the above types, these are also supported:
 - raw (index/show)
 - link (index/show)
   - metadata options for `index` partial:
-    - `:html_options`: used by [ActionView::Helpers::UrlHelper#link_to](https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-link_to)
+    - `:title`: used as link title by [ActionView::Helpers::UrlHelper#link_to](https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-link_to)
+    - `:html_options`: used as link html options by [ActionView::Helpers::UrlHelper#link_to](https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-link_to)
   - metadata options for `show` partial:
-    - `:html_options`: used by [ActionView::Helpers::UrlHelper#link_to](https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-link_to)
+    - `:title`: used as link title by [ActionView::Helpers::UrlHelper#link_to](https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-link_to)
+    - `:html_options`: used as link html options by [ActionView::Helpers::UrlHelper#link_to](https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-link_to)
 - sti
   - metadata options for `index` partial:
     - `:max`: Truncates a given text after a given `max` if text is longer than `max`

--- a/spec/adaptors/wallaby/active_record/model_service_provider/querier_spec.rb
+++ b/spec/adaptors/wallaby/active_record/model_service_provider/querier_spec.rb
@@ -157,19 +157,39 @@ describe Wallaby::ActiveRecord::ModelServiceProvider::Querier do
           context 'boolean' do
             it 'returns eq/in query' do
               keyword = 'boolean:true'
-              expect(subject.search(parameters(q: keyword)).to_sql).to eq "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" = 'true'"
+              if version? '~> 5.2.1'
+                expect(subject.search(parameters(q: keyword)).to_sql).to eq "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" = TRUE"
+              else
+                expect(subject.search(parameters(q: keyword)).to_sql).to eq "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" = 'true'"
+              end
 
               keyword = 'boolean:false'
-              expect(subject.search(parameters(q: keyword)).to_sql).to eq "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" = 'false'"
+              if version? '~> 5.2.1'
+                expect(subject.search(parameters(q: keyword)).to_sql).to eq "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" = FALSE"
+              else
+                expect(subject.search(parameters(q: keyword)).to_sql).to eq "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" = 'false'"
+              end
 
               keyword = 'boolean:=true'
-              expect(subject.search(parameters(q: keyword)).to_sql).to eq "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" = 'true'"
+              if version? '~> 5.2.1'
+                expect(subject.search(parameters(q: keyword)).to_sql).to eq "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" = TRUE"
+              else
+                expect(subject.search(parameters(q: keyword)).to_sql).to eq "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" = 'true'"
+              end
 
               keyword = 'boolean:=false'
-              expect(subject.search(parameters(q: keyword)).to_sql).to eq "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" = 'false'"
+              if version? '~> 5.2.1'
+                expect(subject.search(parameters(q: keyword)).to_sql).to eq "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" = FALSE"
+              else
+                expect(subject.search(parameters(q: keyword)).to_sql).to eq "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" = 'false'"
+              end
 
               keyword = 'boolean:=true,false'
-              expect(subject.search(parameters(q: keyword)).to_sql).to eq "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" IN ('true', 'false')"
+              if version? '~> 5.2.1'
+                expect(subject.search(parameters(q: keyword)).to_sql).to eq "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" IN (TRUE, FALSE)"
+              else
+                expect(subject.search(parameters(q: keyword)).to_sql).to eq "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" IN ('true', 'false')"
+              end
             end
           end
 
@@ -277,7 +297,7 @@ describe Wallaby::ActiveRecord::ModelServiceProvider::Querier do
               expect(subject.search(parameters(q: keyword)).to_sql).to eq minor(
                 {
                   5 => {
-                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" != 'true'"
+                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" != TRUE"
                   }
                 },
                 "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE (\"all_postgres_types\".\"boolean\" != 'true')"
@@ -287,7 +307,7 @@ describe Wallaby::ActiveRecord::ModelServiceProvider::Querier do
               expect(subject.search(parameters(q: keyword)).to_sql).to eq minor(
                 {
                   5 => {
-                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" != 'false'"
+                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" != FALSE"
                   }
                 },
                 "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE (\"all_postgres_types\".\"boolean\" != 'false')"
@@ -297,7 +317,7 @@ describe Wallaby::ActiveRecord::ModelServiceProvider::Querier do
               expect(subject.search(parameters(q: keyword)).to_sql).to eq minor(
                 {
                   5 => {
-                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" != 'true'"
+                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" != TRUE"
                   }
                 },
                 "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE (\"all_postgres_types\".\"boolean\" != 'true')"
@@ -307,7 +327,7 @@ describe Wallaby::ActiveRecord::ModelServiceProvider::Querier do
               expect(subject.search(parameters(q: keyword)).to_sql).to eq minor(
                 {
                   5 => {
-                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" != 'false'"
+                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" != FALSE"
                   }
                 },
                 "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE (\"all_postgres_types\".\"boolean\" != 'false')"
@@ -317,7 +337,7 @@ describe Wallaby::ActiveRecord::ModelServiceProvider::Querier do
               expect(subject.search(parameters(q: keyword)).to_sql).to eq minor(
                 {
                   5 => {
-                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" != 'true'"
+                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" != TRUE"
                   }
                 },
                 "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE (\"all_postgres_types\".\"boolean\" != 'true')"
@@ -327,7 +347,7 @@ describe Wallaby::ActiveRecord::ModelServiceProvider::Querier do
               expect(subject.search(parameters(q: keyword)).to_sql).to eq minor(
                 {
                   5 => {
-                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" != 'false'"
+                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" != FALSE"
                   }
                 },
                 "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE (\"all_postgres_types\".\"boolean\" != 'false')"
@@ -337,7 +357,7 @@ describe Wallaby::ActiveRecord::ModelServiceProvider::Querier do
               expect(subject.search(parameters(q: keyword)).to_sql).to eq minor(
                 {
                   5 => {
-                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" NOT IN ('true', 'false')"
+                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" NOT IN (TRUE, FALSE)"
                   }
                 },
                 "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE (\"all_postgres_types\".\"boolean\" NOT IN ('true', 'false'))"
@@ -347,7 +367,7 @@ describe Wallaby::ActiveRecord::ModelServiceProvider::Querier do
               expect(subject.search(parameters(q: keyword)).to_sql).to eq minor(
                 {
                   5 => {
-                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" NOT IN ('true', 'false')"
+                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" NOT IN (TRUE, FALSE)"
                   }
                 },
                 "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE (\"all_postgres_types\".\"boolean\" NOT IN ('true', 'false'))"
@@ -357,7 +377,7 @@ describe Wallaby::ActiveRecord::ModelServiceProvider::Querier do
               expect(subject.search(parameters(q: keyword)).to_sql).to eq minor(
                 {
                   5 => {
-                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" NOT IN ('true', 'false')"
+                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" NOT IN (TRUE, FALSE)"
                   }
                 },
                 "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE (\"all_postgres_types\".\"boolean\" NOT IN ('true', 'false'))"

--- a/spec/adaptors/wallaby/active_record/model_service_provider/querier_spec.rb
+++ b/spec/adaptors/wallaby/active_record/model_service_provider/querier_spec.rb
@@ -158,35 +158,35 @@ describe Wallaby::ActiveRecord::ModelServiceProvider::Querier do
             it 'returns eq/in query' do
               keyword = 'boolean:true'
               if version? '~> 5.2.1'
-                expect(subject.search(parameters(q: keyword)).to_sql).to eq "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" = TRUE"
+                expect(subject.search(parameters(q: keyword)).to_sql).to eq 'SELECT "all_postgres_types".* FROM "all_postgres_types" WHERE "all_postgres_types"."boolean" = TRUE'
               else
                 expect(subject.search(parameters(q: keyword)).to_sql).to eq "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" = 'true'"
               end
 
               keyword = 'boolean:false'
               if version? '~> 5.2.1'
-                expect(subject.search(parameters(q: keyword)).to_sql).to eq "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" = FALSE"
+                expect(subject.search(parameters(q: keyword)).to_sql).to eq 'SELECT "all_postgres_types".* FROM "all_postgres_types" WHERE "all_postgres_types"."boolean" = FALSE'
               else
                 expect(subject.search(parameters(q: keyword)).to_sql).to eq "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" = 'false'"
               end
 
               keyword = 'boolean:=true'
               if version? '~> 5.2.1'
-                expect(subject.search(parameters(q: keyword)).to_sql).to eq "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" = TRUE"
+                expect(subject.search(parameters(q: keyword)).to_sql).to eq 'SELECT "all_postgres_types".* FROM "all_postgres_types" WHERE "all_postgres_types"."boolean" = TRUE'
               else
                 expect(subject.search(parameters(q: keyword)).to_sql).to eq "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" = 'true'"
               end
 
               keyword = 'boolean:=false'
               if version? '~> 5.2.1'
-                expect(subject.search(parameters(q: keyword)).to_sql).to eq "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" = FALSE"
+                expect(subject.search(parameters(q: keyword)).to_sql).to eq 'SELECT "all_postgres_types".* FROM "all_postgres_types" WHERE "all_postgres_types"."boolean" = FALSE'
               else
                 expect(subject.search(parameters(q: keyword)).to_sql).to eq "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" = 'false'"
               end
 
               keyword = 'boolean:=true,false'
               if version? '~> 5.2.1'
-                expect(subject.search(parameters(q: keyword)).to_sql).to eq "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" IN (TRUE, FALSE)"
+                expect(subject.search(parameters(q: keyword)).to_sql).to eq 'SELECT "all_postgres_types".* FROM "all_postgres_types" WHERE "all_postgres_types"."boolean" IN (TRUE, FALSE)'
               else
                 expect(subject.search(parameters(q: keyword)).to_sql).to eq "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" IN ('true', 'false')"
               end
@@ -297,7 +297,7 @@ describe Wallaby::ActiveRecord::ModelServiceProvider::Querier do
               expect(subject.search(parameters(q: keyword)).to_sql).to eq minor(
                 {
                   5 => {
-                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" != TRUE"
+                    2 => 'SELECT "all_postgres_types".* FROM "all_postgres_types" WHERE "all_postgres_types"."boolean" != TRUE'
                   }
                 },
                 "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE (\"all_postgres_types\".\"boolean\" != 'true')"
@@ -307,7 +307,7 @@ describe Wallaby::ActiveRecord::ModelServiceProvider::Querier do
               expect(subject.search(parameters(q: keyword)).to_sql).to eq minor(
                 {
                   5 => {
-                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" != FALSE"
+                    2 => 'SELECT "all_postgres_types".* FROM "all_postgres_types" WHERE "all_postgres_types"."boolean" != FALSE'
                   }
                 },
                 "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE (\"all_postgres_types\".\"boolean\" != 'false')"
@@ -317,7 +317,7 @@ describe Wallaby::ActiveRecord::ModelServiceProvider::Querier do
               expect(subject.search(parameters(q: keyword)).to_sql).to eq minor(
                 {
                   5 => {
-                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" != TRUE"
+                    2 => 'SELECT "all_postgres_types".* FROM "all_postgres_types" WHERE "all_postgres_types"."boolean" != TRUE'
                   }
                 },
                 "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE (\"all_postgres_types\".\"boolean\" != 'true')"
@@ -327,7 +327,7 @@ describe Wallaby::ActiveRecord::ModelServiceProvider::Querier do
               expect(subject.search(parameters(q: keyword)).to_sql).to eq minor(
                 {
                   5 => {
-                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" != FALSE"
+                    2 => 'SELECT "all_postgres_types".* FROM "all_postgres_types" WHERE "all_postgres_types"."boolean" != FALSE'
                   }
                 },
                 "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE (\"all_postgres_types\".\"boolean\" != 'false')"
@@ -337,7 +337,7 @@ describe Wallaby::ActiveRecord::ModelServiceProvider::Querier do
               expect(subject.search(parameters(q: keyword)).to_sql).to eq minor(
                 {
                   5 => {
-                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" != TRUE"
+                    2 => 'SELECT "all_postgres_types".* FROM "all_postgres_types" WHERE "all_postgres_types"."boolean" != TRUE'
                   }
                 },
                 "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE (\"all_postgres_types\".\"boolean\" != 'true')"
@@ -347,7 +347,7 @@ describe Wallaby::ActiveRecord::ModelServiceProvider::Querier do
               expect(subject.search(parameters(q: keyword)).to_sql).to eq minor(
                 {
                   5 => {
-                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" != FALSE"
+                    2 => 'SELECT "all_postgres_types".* FROM "all_postgres_types" WHERE "all_postgres_types"."boolean" != FALSE'
                   }
                 },
                 "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE (\"all_postgres_types\".\"boolean\" != 'false')"
@@ -357,7 +357,7 @@ describe Wallaby::ActiveRecord::ModelServiceProvider::Querier do
               expect(subject.search(parameters(q: keyword)).to_sql).to eq minor(
                 {
                   5 => {
-                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" NOT IN (TRUE, FALSE)"
+                    2 => 'SELECT "all_postgres_types".* FROM "all_postgres_types" WHERE "all_postgres_types"."boolean" NOT IN (TRUE, FALSE)'
                   }
                 },
                 "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE (\"all_postgres_types\".\"boolean\" NOT IN ('true', 'false'))"
@@ -367,7 +367,7 @@ describe Wallaby::ActiveRecord::ModelServiceProvider::Querier do
               expect(subject.search(parameters(q: keyword)).to_sql).to eq minor(
                 {
                   5 => {
-                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" NOT IN (TRUE, FALSE)"
+                    2 => 'SELECT "all_postgres_types".* FROM "all_postgres_types" WHERE "all_postgres_types"."boolean" NOT IN (TRUE, FALSE)'
                   }
                 },
                 "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE (\"all_postgres_types\".\"boolean\" NOT IN ('true', 'false'))"
@@ -377,7 +377,7 @@ describe Wallaby::ActiveRecord::ModelServiceProvider::Querier do
               expect(subject.search(parameters(q: keyword)).to_sql).to eq minor(
                 {
                   5 => {
-                    2 => "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE \"all_postgres_types\".\"boolean\" NOT IN (TRUE, FALSE)"
+                    2 => 'SELECT "all_postgres_types".* FROM "all_postgres_types" WHERE "all_postgres_types"."boolean" NOT IN (TRUE, FALSE)'
                   }
                 },
                 "SELECT \"all_postgres_types\".* FROM \"all_postgres_types\" WHERE (\"all_postgres_types\".\"boolean\" NOT IN ('true', 'false'))"

--- a/spec/support/helpers/versions.rb
+++ b/spec/support/helpers/versions.rb
@@ -6,6 +6,23 @@ module Versions
   def tiny(results, other = nil)
     results[Rails::VERSION::MAJOR].try(:[], Rails::VERSION::MINOR).try(:[], Rails::VERSION::TINY) || other
   end
+
+  def version?(string)
+    operator = string[/\<|\<\=|\=\>|\>|\~\>/]
+    _, major, minor, tiny = string.match(/(\d+)\.?(\d+)?\.?(\d+)?/).to_a.map(&:to_i)
+    operator = '==' if operator.blank?
+    check_version operator, major, minor, tiny
+  end
+
+  def check_version(operator, major, minor, tiny)
+    if operator == '~>'
+      Rails::VERSION::MAJOR == major && Rails::VERSION::MINOR == minor
+    else
+      v1 = Gem::Version.new(Rails::VERSION::STRING)
+      v2 = Gem::Version.new([major, minor, tiny].compact.join('.'))
+      v1.public_send(operator, v2)
+    end
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/support/shared_examples/views/index.rb
+++ b/spec/support/shared_examples/views/index.rb
@@ -14,7 +14,7 @@ RSpec.shared_examples 'index partial' do |field_name, options = {}|
 
   unless options[:skip_general] || options[:skip_all]
     it 'renders the index partial' do
-      expect(rendered).to include h(expected_value.to_s)
+      expect(rendered).to include(options[:skip_escaping] ? expected_value.to_s : h(expected_value.to_s))
     end
   end
 

--- a/spec/views/wallaby/resources/index/_link.csv.erb_spec.rb
+++ b/spec/views/wallaby/resources/index/_link.csv.erb_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+field_name = 'string'
+describe field_name, :current_user do
+  it_behaves_like \
+    'index csv partial', field_name,
+    value: 'https://reinteractive.com/',
+    partial_name: 'link',
+    expected_value: 'https://reinteractive.com/'
+end

--- a/spec/views/wallaby/resources/index/_link.html.erb_spec.rb
+++ b/spec/views/wallaby/resources/index/_link.html.erb_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+partial_name = 'index/link'
+describe partial_name, :current_user do
+  let(:partial)   { "wallaby/resources/#{partial_name}.html.erb" }
+  let(:value)     { 'https://reinteractive.com/' }
+  let(:metadata)  { { label: 'Rails Developers', html_options: { target: '_blank' } } }
+
+  before { render partial, value: value, metadata: metadata }
+
+  it 'renders the link' do
+    expect(rendered).to include '<a target="_blank" href="https://reinteractive.com/">Rails Developers</a>'
+  end
+end

--- a/spec/views/wallaby/resources/index/_link.html.erb_spec.rb
+++ b/spec/views/wallaby/resources/index/_link.html.erb_spec.rb
@@ -1,14 +1,13 @@
 require 'rails_helper'
 
-partial_name = 'index/link'
-describe partial_name, :current_user do
-  let(:partial)   { "wallaby/resources/#{partial_name}.html.erb" }
-  let(:value)     { 'https://reinteractive.com/' }
-  let(:metadata)  { { label: 'Rails Developers', html_options: { target: '_blank' } } }
-
-  before { render partial, value: value, metadata: metadata }
-
-  it 'renders the link' do
-    expect(rendered).to include '<a target="_blank" href="https://reinteractive.com/">Rails Developers</a>'
-  end
+field_name = 'string'
+type = type_from __FILE__
+describe field_name do
+  it_behaves_like \
+    "#{type} partial", field_name,
+    partial_name: 'link',
+    value: 'https://reinteractive.com/',
+    metadata: { title: 'Rails Developers', html_options: { target: '_blank' } },
+    skip_escaping: true,
+    expected_value: '<a target="_blank" href="https://reinteractive.com/">Rails Developers</a>'
 end

--- a/spec/views/wallaby/resources/show/_link.html.erb_spec.rb
+++ b/spec/views/wallaby/resources/show/_link.html.erb_spec.rb
@@ -4,7 +4,7 @@ partial_name = 'show/link'
 describe partial_name, :current_user do
   let(:partial)   { "wallaby/resources/#{partial_name}.html.erb" }
   let(:value)     { 'https://reinteractive.com/' }
-  let(:metadata)  { { label: 'Rails Developers', html_options: { target: '_blank' } } }
+  let(:metadata)  { { title: 'Rails Developers', html_options: { target: '_blank' } } }
 
   before { render partial, value: value, metadata: metadata }
 

--- a/spec/views/wallaby/resources/show/_link.html.erb_spec.rb
+++ b/spec/views/wallaby/resources/show/_link.html.erb_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+partial_name = 'show/link'
+describe partial_name, :current_user do
+  let(:partial)   { "wallaby/resources/#{partial_name}.html.erb" }
+  let(:value)     { 'https://reinteractive.com/' }
+  let(:metadata)  { { label: 'Rails Developers', html_options: { target: '_blank' } } }
+
+  before { render partial, value: value, metadata: metadata }
+
+  it 'renders the belongs_to' do
+    expect(rendered).to include '<a target="_blank" href="https://reinteractive.com/">Rails Developers</a>'
+  end
+
+  context 'when value is nil' do
+    let(:value) { nil }
+    it 'renders null' do
+      expect(rendered).to include view.null
+    end
+  end
+end


### PR DESCRIPTION
Adds a link type to Wallaby allowing you to do something like this in a decorator:

```
class ProductDecorator < Wallaby::ResourceDecorator
  include ActionView::Helpers::UrlHelper

  def view_product
    Rails.application.routes.url_helpers.product_url(id)
  end

  self.index_field_names << 'view_product'

  self.index_fields[:view_product] = {
    type: 'link',
    label: 'View Product',
    html_options: {target: '_blank'}
  }
end
```