### PR TITLE
chore: bump to use wallaby-active_record 0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Data audit (use papertrail) (maybe..)
 - Batch data action (maybe..)
 
+## [6.1.3](https://github.com/wallaby-rails/wallaby-core/releases/tag/6.1.3) - 2020-04-19
+
+- chore: bump to use wallaby-active_record 0.2.6 ([#186](https://github.com/wallaby-rails/wallaby/pull/186))
+
 ## [6.1.2](https://github.com/wallaby-rails/wallaby-core/releases/tag/6.1.2) - 2020-04-12
 
 - chore: use wallaby_user instead, will take out current_user in the future ([#185](https://github.com/wallaby-rails/wallaby/pull/185))

--- a/lib/wallaby/version.rb
+++ b/lib/wallaby/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wallaby
-  VERSION = '6.1.2' # :nodoc:
+  VERSION = '6.1.3' # :nodoc:
 end

--- a/wallaby.gemspec
+++ b/wallaby.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'wallaby-core'
 
   # This will determine wallaby-core's version
-  s.add_dependency 'wallaby-active_record', '0.2.5'
+  s.add_dependency 'wallaby-active_record', '0.2.6'
 
   # assets gems
   s.add_dependency 'bootstrap'


### PR DESCRIPTION
as titled