### PR TITLE
chore: drop EOL Ruby/Rails, add Ruby 4.0/Rails 8.1, tighten gemspec c…

### DIFF
--- a/.gemfiles/Gemfile.rails-8.1
+++ b/.gemfiles/Gemfile.rails-8.1
@@ -8,7 +8,7 @@ source 'https://rubygems.org'
 # To use a debugger
 # gem 'byebug', group: [:development, :test]
 
-gem 'rails', '~> 7.0.0'
+gem 'rails', '~> 8.1.0'
 
 gem 'wallaby-cop', path: '../wallaby-cop'
 gem 'wallaby', path: '../wallaby'

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -43,13 +43,15 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         # NOTE: check the versions that Ruby supports at https://www.ruby-lang.org/en/downloads/branches/
-        ruby: ['3.3', '3.2', '3.1']
+        ruby: ['4.0', '3.4', '3.3']
         # NOTE: check the versions that Rails supports at https://guides.rubyonrails.org/maintenance_policy.html
-        rails: ['8.0', '7.2', '7.1', '7.0']
-        # NOTE: .keep
+        rails: ['8.1', '8.0', '7.2', '7.1']
+        # NOTE: Ruby 4.0 may not be compatible with older Rails series
         exclude:
-          - ruby: '3.1'
-            rails: '8.0'
+          - ruby: '4.0'
+            rails: '7.2'
+          - ruby: '4.0'
+            rails: '7.1'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,9 @@
 
 source 'https://rubygems.org'
 
-ruby '3.2.2'
+ruby '4.0.6'
 
-gem 'rails', '~> 8.0.0'
+gem 'rails', '~> 8.1.0'
 
 gem 'wallaby', path: './wallaby'
 gem 'wallaby-core', path: './wallaby-core'

--- a/wallaby-cop/wallaby-cop.gemspec
+++ b/wallaby-cop/wallaby-cop.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['rubocop.yml', 'lib/wallaby-cop.rb']
 
-  spec.add_dependency 'gitlab-styles'
+  spec.add_dependency 'gitlab-styles', '~> 14.0'
   spec.add_dependency 'rubocop-rails'
   spec.add_dependency 'rubocop-rspec'
 end

--- a/wallaby-view/wallaby-view.gemspec
+++ b/wallaby-view/wallaby-view.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   ]
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'railties', '>= 4.2.0'
+  spec.add_dependency 'railties', '>= 7.1.0'
 
   spec.add_development_dependency 'github-markup'
   spec.add_development_dependency 'redcarpet'

--- a/wallaby/wallaby.gemspec
+++ b/wallaby/wallaby.gemspec
@@ -36,9 +36,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'wallaby-active_record', '~> 0.3.0'
 
   # assets gems
-  spec.add_dependency 'jbuilder'
+  spec.add_dependency 'jbuilder', '~> 2.15'
+  # NOTE: sass-rails is deprecated; consider migrating to cssbundling-rails or dartsass-rails in the future
   spec.add_dependency 'sass-rails'
-  spec.add_dependency 'sprockets-rails'
+  spec.add_dependency 'sprockets-rails', '~> 3.5'
 
   spec.add_development_dependency 'foreman'
   spec.add_development_dependency 'wallaby-cop'


### PR DESCRIPTION
…onstraints

- Drop EOL Ruby 3.1/3.2 and Rails 7.0 from CI matrix
- Add Ruby 4.0, Ruby 3.4, and Rails 8.1 to CI matrix
- Exclude Ruby 4.0 + Rails 7.x combinations (potential incompatibility)
- Update Gemfile: ruby '4.0.6', rails '~> 8.1.0'
- Create .gemfiles/Gemfile.rails-8.1 for Rails 8.1 CI
- wallaby-view: tighten railties constraint from >= 4.2.0 to >= 7.1.0
- wallaby: add version constraints on jbuilder (~> 2.15) and sprockets-rails (~> 3.5)
- wallaby-cop: add gitlab-styles ~> 14.0 constraint
- Note sass-rails deprecation for future migration

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Thanks for contributing! -->
