### PR TITLE
fix: upgrade transitive immutable dependency to fix CVE-2026-29063

### DIFF
--- a/wallaby/package.json
+++ b/wallaby/package.json
@@ -25,5 +25,8 @@
     "bundle-scss": "^1.5.1",
     "esbuild": "^0.25.0",
     "scss-bundle": "^3.1.2"
+  },
+  "resolutions": {
+    "immutable": "^4.3.8"
   }
 }

--- a/wallaby/yarn.lock
+++ b/wallaby/yarn.lock
@@ -507,10 +507,10 @@ ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.1.tgz#5073e554cd42c5b33b394375f538b8593e34d4ef"
   integrity sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==
 
-immutable@^4.0.0:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.5.tgz#f8b436e66d59f99760dc577f5c99a4fd2a5cc5a0"
-  integrity sha512-8eabxkth9gZatlwl5TBuJnCsoTADlL6ftEr7A4qgdaTsPyreilDSnUk57SO+jfKcNtxPa22U5KK6DSeAYhpBJw==
+immutable@^4.0.0, immutable@^4.3.8:
+  version "4.3.9"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.9.tgz#c98349e05e9c6e2a4d8fe88ac0b363e0d536b544"
+  integrity sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==
 
 inflight@^1.0.4:
   version "1.0.6"


### PR DESCRIPTION
- Add yarn resolutions to force immutable@^4.3.8 in wallaby/
- immutable is a transitive dependency via scss-bundle -> sass
- Upgraded from 4.3.5 to 4.3.9, patching the Prototype Pollution vulnerability
- See https://github.com/wallaby-rails/wallaby-rails/security/dependabot/14

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Thanks for contributing! -->
