### PR TITLE
fix: upgrade brace-expansion to fix CVE-2026-13149

### DIFF
--- a/wallaby/package.json
+++ b/wallaby/package.json
@@ -27,6 +27,7 @@
     "scss-bundle": "^3.1.2"
   },
   "resolutions": {
+    "brace-expansion": "^1.1.16",
     "immutable": "^4.3.8"
   }
 }

--- a/wallaby/yarn.lock
+++ b/wallaby/yarn.lock
@@ -270,10 +270,10 @@ bootstrap@^4.6.1, bootstrap@^4.6.2:
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.6.2.tgz#8e0cd61611728a5bf65a3a2b8d6ff6c77d5d7479"
   integrity sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==
 
-brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+brace-expansion@^1.1.16, brace-expansion@^1.1.7:
+  version "1.1.16"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.16.tgz#723d3a30c0558c225abc9fc479a73e14e26c3c2f"
+  integrity sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"


### PR DESCRIPTION
- Add yarn resolutions to force brace-expansion@^1.1.16 in wallaby/
- brace-expansion is a transitive dependency via bundle-scss -> globby -> fast-glob -> micromatch -> minimatch
- Upgraded from 1.1.11 to 1.1.16, patching the exponential-time DoS vulnerability
- Also keep immutable@^4.3.8 resolution for previously fixed CVEs
- See https://github.com/wallaby-rails/wallaby-rails/security/dependabot/21

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Thanks for contributing! -->
