### PR TITLE
fix: upgrade summernote to 0.9.1 to fix CVE-2024-37629

### DIFF
--- a/wallaby/package.json
+++ b/wallaby/package.json
@@ -17,7 +17,7 @@
     "moment": "^2.29.1",
     "moment-timezone": "^0.5.40",
     "popper.js": "^1.16.1",
-    "summernote": "^0.8.20",
+    "summernote": "^0.9.1",
     "tempusdominus-bootstrap-4": "^5.1.2",
     "typeahead.js": "^0.11.1"
   },

--- a/wallaby/yarn.lock
+++ b/wallaby/yarn.lock
@@ -769,10 +769,10 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
-summernote@^0.8.20:
-  version "0.8.20"
-  resolved "https://registry.yarnpkg.com/summernote/-/summernote-0.8.20.tgz#395905f2cec0aceebc712edc019d91b8ef88f7cf"
-  integrity sha512-W9RhjQjsn+b1s9xiJQgJbCiYGJaDAc9CdEqXo+D13WuStG8lCdtKaO5AiNiSSMJsQJN2EfGSwbBQt+SFE2B8Kw==
+summernote@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/summernote/-/summernote-0.9.1.tgz#28413746eb2eeeca733ac13e36372a0ff2fb093a"
+  integrity sha512-5Hfuey6+N0XIbk8ZpkGEVDmrkRVRHZWKBhw/072i9/TJLaWUKboB+KOyyd6AzDP2CQs1O6or4zRTU8HY30kt4w==
 
 supports-color@^7.1.0:
   version "7.2.0"


### PR DESCRIPTION
- Upgrade summernote from 0.8.20 to 0.9.1 (latest)
- CVE-2024-37629: XSS vulnerability via Code View Function (affects <= 0.8.20)
- See https://github.com/wallaby-rails/wallaby-rails/security/dependabot/3

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Thanks for contributing! -->
